### PR TITLE
Add the license files to the wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+license_files =
+    LICENSE
+    LICENSES/*.txt


### PR DESCRIPTION
Added modifications to include the LICENSE and the files in the LICENSES directory when installing with pip.